### PR TITLE
Update GNOME runtime to version 46

### DIFF
--- a/io.github.orontee.Argos.json
+++ b/io.github.orontee.Argos.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.orontee.Argos",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "argos",
     "finish-args" : [


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.